### PR TITLE
Darkmode support for `Special:UnreviewedPages` and `Special:PendingChanges`

### DIFF
--- a/modules/ext.flaggedRevs.basic/default.css
+++ b/modules/ext.flaggedRevs.basic/default.css
@@ -198,19 +198,19 @@ span.flaggedrevs-icon {
 
 /* Special pages */
 .fr-pending-long {
-	background-color: #eaecf0;
+	background-color: var( --clr-surface-2, #eaecf0 );
 }
 
 .fr-pending-long2 {
-	background-color: #fee7e6;
+	background-color: var( --clr-surface-3, #fee7e6 );
 }
 
 .fr-pending-long3 {
-	background-color: #c8ccd1;
+	background-color: var( --clr-surface-4, #fee7e6 );
 }
 
 .fr-unreviewed-unwatched {
-	background-color: #fee7e6;
+	background-color: var( --clr-surface-3, #fee7e6 );
 }
 
 .mw-fr-reviewlink {

--- a/modules/ext.flaggedRevs.basic/default.css
+++ b/modules/ext.flaggedRevs.basic/default.css
@@ -206,7 +206,7 @@ span.flaggedrevs-icon {
 }
 
 .fr-pending-long3 {
-	background-color: var( --clr-surface-4, #fee7e6 );
+	background-color: var( --clr-surface-4, #c8ccd1 );
 }
 
 .fr-unreviewed-unwatched {


### PR DESCRIPTION
Currently when viewing `Special:UnreviewedPages` or `Special:PendingChanges` and there are pages that are not reviewed for a longer time and hence use `fr-pending-long` (or even `fr-pending-long2` or `fr-pending-long3`) or if pages are unwatched      they are pretty hard to read due to hardcoded colors.
This PR replaces the hardcoded colors with color vars.

(hope this style sheet is still used)

tested via browser dev tools

before:
![image](https://github.com/user-attachments/assets/00f5a1f8-eec2-4670-b825-1cecc07e2269)

after:
![image](https://github.com/user-attachments/assets/dbd8e4b2-bd03-4efa-b331-1674434efe32)
